### PR TITLE
Upgrade hugo to version 0.88.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.16-alpine AS go
 
-FROM klakegg/hugo:0.84.1-alpine
+FROM klakegg/hugo:0.88.0-alpine
 COPY --from=go /usr/local/go/ /usr/local/go/
 
 RUN apk update && apk upgrade && \


### PR DESCRIPTION
Note: with 0.88.0 release Go was upgraded to v 1.17. Later on this was rolled back in 0.88.1 release due to issues, hence this PR has Hugo upgrade only. 